### PR TITLE
Fix log messages of boxel, missing source

### DIFF
--- a/RegionMap.py
+++ b/RegionMap.py
@@ -104,17 +104,19 @@ def main():
 
                 if region2 is not None:
                     print('Boxel of system {0} at ({1},{2},{3}) is in region {4} ({5})'.format(
-                        x,
-                        y,
-                        z,
+                        sysdata['name'],
+                        sysdata['boxel']['x'],
+                        sysdata['boxel']['y'],
+                        sysdata['boxel']['z'],
                         region2[0],
                         region2[1]
                     ))
                 else:
                     print('Boxel of system {0} at ({1},{2},{3}) is outside the region map'.format(
-                        x,
-                        y,
-                        z
+                        sysdata['name'],
+                        sysdata['boxel']['x'],
+                        sysdata['boxel']['y'],
+                        sysdata['boxel']['z'],
                     ))
 
 if __name__ == '__main__':


### PR DESCRIPTION
Boxel print messages were missing their source and throwing an error of:

```
Traceback (most recent call last):
  File "RegionMap.py", line 121, in <module>
    main()
  File "RegionMap.py", line 107, in main
    x,
NameError: name 'x' is not defined
```